### PR TITLE
Ignore swift upload errors if they are caused by a failure to create a container

### DIFF
--- a/wandio/swift.py
+++ b/wandio/swift.py
@@ -145,7 +145,13 @@ def upload(local_file, container, obj, options=None, swift=None):
     })
     for res in results:
         if not res["success"]:
-            raise res["error"]
+            # Failing to create a container is a warning, not an error -- Shane
+            # Ref: https://github.com/openstack/python-swiftclient/blob/master/swiftclient/shell.py
+            # inside function st_upload()
+            if 'action' in res and res['action'] == "create_container":
+                continue
+            else:
+                raise res["error"]
 
 
 def download(container, obj, local_file=None, local_dir=None,


### PR DESCRIPTION
Swift returns a 403 forbidden whenever a user without the ability
to create a container tries to upload a file (seems stupid, but
whatever). We need to ignore this error and carry on with the
upload iterator to ensure that the upload goes ahead anyway.
If the container exists and we got a 403 for no good reason, the
upload should succeed.