### PR TITLE
convert bytes to str for HttpReader

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 pywandio (0.2.1) unstable; urgency=medium
 
-  * bugfix: decode read bytes to str for GenericReader
+  * bugfix: decode bytes to str for HttpReader iterator
 
  -- Alistair King <software@caida.org>  Wed, 13 May 2020 16:00:00 -0800
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pywandio (0.2.1) unstable; urgency=medium
+
+  * bugfix: decode read bytes to str for GenericReader
+
+ -- Alistair King <software@caida.org>  Wed, 13 May 2020 16:00:00 -0800
+
 pywandio (0.2.0) unstable; urgency=medium
 
   * python3 compatible

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name='pywandio',
-    version='0.2',
+    version='0.2.1',
     description='High-level file IO library',
     url='https://github.com/CAIDA/pywandio',
     author='Alistair King, Chiara Orsini, Mingwei Zhang',

--- a/wandio/file.py
+++ b/wandio/file.py
@@ -29,11 +29,7 @@ class GenericReader(object):
         return self
 
     def __next__(self):
-        res = next(self.fh)
-        if isinstance(res, bytes):
-            # try decode bytes to string
-            res = res.decode()
-        return res
+        return next(self.fh)
 
     def next(self):
         return self.__next__()

--- a/wandio/file.py
+++ b/wandio/file.py
@@ -29,7 +29,11 @@ class GenericReader(object):
         return self
 
     def __next__(self):
-        return next(self.fh)
+        res = next(self.fh)
+        if isinstance(res, bytes):
+            # try decode bytes to string
+            res = res.decode()
+        return res
 
     def next(self):
         return self.__next__()

--- a/wandio/http.py
+++ b/wandio/http.py
@@ -10,6 +10,7 @@ try:
 except ImportError:
     from urllib2 import urlopen, Request
 
+
 def http_stat(filename):
     request = Request(filename)
     request.get_method = lambda: 'HEAD'
@@ -39,3 +40,6 @@ class HttpReader(wandio.file.GenericReader):
     def __init__(self, url):
         self.url = url
         super(HttpReader, self).__init__(urlopen(self.url))
+
+    def __next__(self):
+        return next(self.fh).decode()


### PR DESCRIPTION
This fixes the issue where reading lines using iterator using HttpReader returns `bytes` instead of `str`, causing downstream script crashes.

**EDIT**: revise this pr to only change the `__next__` call for HttpReader. This PR should only have effects when user calls `for line in fh`-alike calls.