### PR TITLE
set "utf-8" as default encoding option

### DIFF
--- a/wandio/compressed.py
+++ b/wandio/compressed.py
@@ -86,7 +86,7 @@ class CompressedReader(wandio.file.GenericReader):
                 break
         if not len(res) and not len(self.buf) and self.eof:
             return None
-        return res.decode()
+        return res.decode("utf-8")
 
 
 class CompressedWriter(wandio.file.GenericWriter):

--- a/wandio/http.py
+++ b/wandio/http.py
@@ -42,4 +42,4 @@ class HttpReader(wandio.file.GenericReader):
         super(HttpReader, self).__init__(urlopen(self.url))
 
     def __next__(self):
-        return next(self.fh).decode()
+        return next(self.fh).decode("utf-8")


### PR DESCRIPTION
this should address the `decode()` throwing `UnicdoeDecodeException` in Python2 usage (#16).