### PR TITLE
Add options to set encoding or disable decode

### DIFF
--- a/wandio/compressed.py
+++ b/wandio/compressed.py
@@ -86,7 +86,10 @@ class CompressedReader(wandio.file.GenericReader):
                 break
         if not len(res) and not len(self.buf) and self.eof:
             return None
-        return res.decode("utf-8")
+        if self.decode:
+            return res.decode(self.encoding)
+        else:
+            return res
 
 
 class CompressedWriter(wandio.file.GenericWriter):

--- a/wandio/file.py
+++ b/wandio/file.py
@@ -16,8 +16,10 @@ class GenericReader(object):
     Wraps a file-like object
     """
 
-    def __init__(self, fh):
+    def __init__(self, fh, decode=True, encoding="utf-8"):
         self.fh = fh
+        self.decode = decode
+        self.encoding = encoding
 
     def __enter__(self):
         return self

--- a/wandio/http.py
+++ b/wandio/http.py
@@ -42,4 +42,8 @@ class HttpReader(wandio.file.GenericReader):
         super(HttpReader, self).__init__(urlopen(self.url))
 
     def __next__(self):
-        return next(self.fh).decode("utf-8")
+        res = next(self.fh)
+        if self.decode:
+            return res.decode(self.encoding)
+        else:
+            return res

--- a/wandio/opener.py
+++ b/wandio/opener.py
@@ -99,9 +99,12 @@ class Writer(wandio.file.GenericWriter):
         super(Writer, self).__init__(fh)
 
 
-def wandio_open(filename, mode="r"):
+def wandio_open(filename, mode="r", decode=True, encoding="utf-8"):
     if mode == "r":
-        return Reader(filename)
+        reader = Reader(filename)
+        reader.fh.decode = decode
+        reader.fh.encoding = encoding
+        return reader
     elif mode == "w":
         return Writer(filename)
     else:


### PR DESCRIPTION
For file operations that prefers raw bytes:
```python
with wandio.open(filename, decode=False) as fh:
```

For operations that needs other encodings:
```python
with wandio.open(filename, encoding="ascii") as fh:
```