### PR TITLE
Allow on-disk files to be read using binary mode 'rb'

### DIFF
--- a/wandio/file.py
+++ b/wandio/file.py
@@ -79,8 +79,8 @@ class StdinReader(GenericReader):
 
 class SimpleReader(GenericReader):
 
-    def __init__(self, filename):
-        super(SimpleReader, self).__init__(open(filename, "r"))
+    def __init__(self, filename, mode):
+        super(SimpleReader, self).__init__(open(filename, mode))
 
 
 class SimpleWriter(GenericWriter):

--- a/wandio/opener.py
+++ b/wandio/opener.py
@@ -105,7 +105,7 @@ def wandio_open(filename, mode="r"):
     elif mode == "w":
         return Writer(filename)
     else:
-        raise ValueError("Invalid mode. Mode must be either 'r' or 'w'")
+        raise ValueError("Invalid mode. Mode must be either 'r', 'rb', or 'w'")
 
 
 def wandio_stat(filename):

--- a/wandio/opener.py
+++ b/wandio/opener.py
@@ -20,7 +20,7 @@ import wandio.swift
 
 class Reader(wandio.file.GenericReader):
 
-    def __init__(self, filename, options=None):
+    def __init__(self, filename, mode='r', options=None):
         self.filename = filename
 
         # check for the transport types first (HTTP, Swift, Simple)
@@ -39,7 +39,7 @@ class Reader(wandio.file.GenericReader):
 
         # then it must be a simple local file
         else:
-            fh = wandio.file.SimpleReader(self.filename)
+            fh = wandio.file.SimpleReader(self.filename, mode)
 
         assert fh
 
@@ -100,8 +100,8 @@ class Writer(wandio.file.GenericWriter):
 
 
 def wandio_open(filename, mode="r"):
-    if mode == "r":
-        return Reader(filename)
+    if mode == "r" or mode == "rb":
+        return Reader(filename, mode=mode)
     elif mode == "w":
         return Writer(filename)
     else:
@@ -147,11 +147,14 @@ def read_main():
                         help="Force use of next (for testing)")
 
     parser.add_argument('files', nargs='+', help='Files to read from')
+    parser.add_argument('-m', '--file-mode', required=False,
+                        type=str, default='r',
+                        help="Open files using this file mode")
 
     opts = vars(parser.parse_args())
 
     for filename in opts['files']:
-        with Reader(filename) as fh:
+        with Reader(filename, mode=opts['file_mode']) as fh:
             if opts['use_next']:
                 # sys.stderr.write("Reading using 'next'\n")
                 for line in fh:


### PR DESCRIPTION
The SimpleReader under python3 tends to get unhappy when asked to read a binary file from local disk.

The problem is that these files were always opened using 'r' mode, which means that python3 would treat the contents as utf-8 and try to decode whatever it reads into useful text. When the decoding inevitably fails, python3 would throw an exception.

This PR adds an optional `mode` argument to the SimpleReader `init()` method so that the reader can be forced to open the file in binary mode. `wandio_open()` has also been updated to allow `rb` as a valid mode, and will pass that on to the Reader init method.

Finally, I've also added a `-m` option to `read_main()` (aka `pywandio-cat`) which allows the mode to be specified via CLI argument.