### PR TITLE
No longer build python2 packages.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,16 +3,12 @@ Maintainer: CAIDA Software Maintainer <software@caida.org>
 Section: python
 Priority: optional
 Build-Depends: dh-python, debhelper (>= 9),
-  python-setuptools, python3-setuptools, python-all-dev, python3-all-dev,
-  python-keystoneclient, python3-keystoneclient,
-  python-swiftclient, python3-swiftclient,
+  python3-setuptools,
+  python3-all-dev,
+  python3-keystoneclient,
+  python3-swiftclient,
 Standards-Version: 3.9.6
 Homepage: https://github.com/CAIDA/pywandio
-
-Package: python-pywandio
-Architecture: any
-Depends: ${misc:Depends}, ${python:Depends}, ${shlibs:Depends}
-Description: Python interface to libwandio
 
 Package: python3-pywandio
 Architecture: any

--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@
 # Tue, 13 Aug 2019 13:42:49 -0700
 export PYBUILD_NAME=pywandio
 %:
-	dh $@ --with python2,python3 --buildsystem=pybuild
+	dh $@ --with python3 --buildsystem=pybuild
 
 override_dh_auto_install:
 	dh_auto_install


### PR DESCRIPTION
Modern Debian/Ubuntu releases no longer have python2 support.